### PR TITLE
chore(actions): add skip duplicate action to supported actions

### DIFF
--- a/ALLOWED_ACTIONS.yaml
+++ b/ALLOWED_ACTIONS.yaml
@@ -9,6 +9,7 @@ cirrus-actions/rebase: c473b716e3fcde0c6bf67416e2c2882830ad40f6  # 1.5
 cypress-io/github-action: 6b3bc3a1c27198cda160cb03307c43bc998aa564  # v2.11.0
 docker/login-action: 28218f9b04b4f3f62068d7b6ce6ca5b26e35336c  # v1.9.0
 ffurrer2/extract-release-notes: 72ce6a57083368f4a785f875a52eb972255823fc  # v1.7.0
+fkirc/skip-duplicate-actions: f75dd6564bb646f95277dc8c3b80612e46a4a1ea  # v3.4.1
 fusion-engineering/setup-git-credentials: 1ffa9266dc7fa821d6419a2b6484d8688b42814d  # v2.0.6
 google-github-actions/deploy-appengine: 2906c455f0ddd438509bfb2e9f995ef5092cee21  # v0.3.1
 google-github-actions/setup-gcloud: daadedc81d5f9d3c06d2c92f49202a3cc2b919ba  # v0.2.1


### PR DESCRIPTION
https://github.com/fkirc/skip-duplicate-actions

I add this action because it will come in handy to reduce costs and time spend waiting for ci.

It basicaly allows skipping a workflow based on file path even for required workflows.