### PR TITLE
chore(action): updated deprecated version of ssh-agent

### DIFF
--- a/ALLOWED_ACTIONS.yaml
+++ b/ALLOWED_ACTIONS.yaml
@@ -38,6 +38,6 @@ repo-sync/pull-request: 65785d95a5a466e46a9d0708933a3bd51bbf9dde  # v2.6.2
 snok/install-poetry: 5e4414407e59f94f2148bcb253917dfc22dee7d9  # v1.3.0
 thomaseizinger/create-pull-request: 708b87f1bf8075327bd126082bb2430020bab194  # 1.0.0
 uesteibar/reviewer-lottery: 5531ef7fe55d814c8f8fbab12de4ff74d15b41ed  # v2
-webfactory/ssh-agent: cb8b21017acfd319f0f4eb320ae495f22c36d0a7  # v0.5.2
+webfactory/ssh-agent: 836c84ec59a0e7bc0eabc79988384eb567561ee2  # v7.0.0
 wzieba/Firebase-Distribution-Github-Action: d6e3b20d53da54e1ffd2082a8132e120b5bd1bb2  # v1.3.2
 xt0rted/pull-request-comment-branch: f2f07162618551540507cbd00ddf16ffcaa0c72f  # v1.3.0


### PR DESCRIPTION
They have updated node v12 to node v16 which is mandatory by Github now.
https://github.com/webfactory/ssh-agent/releases/tag/v0.6.0

Warnings in LumApps repo: https://github.com/lumapps/mobile-customers/actions/runs/3760072757