### PR TITLE
Bump dorny/paths-filter to 2.11.1

### DIFF
--- a/ALLOWED_ACTIONS.yaml
+++ b/ALLOWED_ACTIONS.yaml
@@ -15,7 +15,7 @@ docker/build-push-action: a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229 # v2
 docker/login-action: 28218f9b04b4f3f62068d7b6ce6ca5b26e35336c  # v1.9.0
 docker/metadata-action: f206c36955d3cc6213c38fb3747d9ba4113e686a  # v4.0.0
 docker/setup-buildx-action: 8c0edbc76e98fa90f69d9a2c020dcb50019dc325  # v2.2.1
-dorny/paths-filter: b2feaf19c27470162a626bd6fa8438ae5b263721  #2.10.2
+dorny/paths-filter: 4512585405083f25c027a35db413c2b3b9006d50  #2.11.1
 ffurrer2/extract-release-notes: 72ce6a57083368f4a785f875a52eb972255823fc  # v1.7.0
 fkirc/skip-duplicate-actions: f75dd6564bb646f95277dc8c3b80612e46a4a1ea  # v3.4.1
 fusion-engineering/setup-git-credentials: 1ffa9266dc7fa821d6419a2b6484d8688b42814d  # v2.0.6


### PR DESCRIPTION
Bump  dorny/paths-filter from 2.10.2 to 2.11.1

I would like to be able to use the latest version in core-ts


It looks like the action is not used by a repo at this time