### PR TITLE
chore(doc): update to suggests using version

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,6 @@ jobs:
     name: Github-actions-validator
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: lumapps/github-actions-validator@master
+    - uses: actions/checkout@v3
+    - uses: lumapps/github-actions-validator@vX
 ```


### PR DESCRIPTION
using master can prevent merge on other repo while targetting a tag will prevent only repo using latest tag